### PR TITLE
Changed some tests to avoid random getDeclaredFields() results

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
@@ -60,22 +60,16 @@ public class ExposeFieldsTest {
     ClassWithExposedFields[] objects = { object1, object2, object3 };
 
     String json = gson.toJson(objects);
-    String expected =
-        '['
-            + object1.getExpectedJson()
-            + ','
-            + object2.getExpectedJson()
-            + ','
-            + object3.getExpectedJson()
-            + ']';
-
-    assertThat(json).isEqualTo(expected);
+    assertThat(json).isAnyOf("[{\"a\":1,\"d\":2.0},{\"d\":2.0},{\"a\":2,\"d\":2.0}]",
+                            "[{\"d\":2.0,\"a\":1},{\"d\":2.0},{\"a\":2,\"d\":2.0}]",
+                            "[{\"d\":2.0,\"a\":1},{\"d\":2.0},{\"d\":2.0,\"a\":2}]",
+                            "[{\"a\":1,\"d\":2.0},{\"d\":2.0},{\"d\":2.0,\"a\":2}]");
   }
 
   @Test
   public void testExposeAnnotationSerialization() {
     ClassWithExposedFields target = new ClassWithExposedFields(1, 2);
-    assertThat(gson.toJson(target)).isEqualTo(target.getExpectedJson());
+    assertThat(gson.toJson(target)).isAnyOf("{\"a\":1,\"d\":2.0}", "{\"d\":2.0,\"a\":1}");
   }
 
   @Test
@@ -104,16 +98,16 @@ public class ExposeFieldsTest {
     assertThat(obj.a).isEqualTo(0);
     assertThat(obj.b).isEqualTo(1);
   }
-  
+
   @Test
   public void testExposedInterfaceFieldSerialization() {
     String expected = "{\"interfaceField\":{}}";
     ClassWithInterfaceField target = new ClassWithInterfaceField(new SomeObject());
     String actual = gson.toJson(target);
-    
+
     assertThat(actual).isEqualTo(expected);
   }
-  
+
   @Test
   public void testExposedInterfaceFieldDeserialization() {
     String json = "{\"interfaceField\":{}}";
@@ -160,21 +154,21 @@ public class ExposeFieldsTest {
     private final int a = 0;
     private final int b = 1;
   }
-  
+
   private static interface SomeInterface {
     // Empty interface
   }
-  
+
   private static class SomeObject implements SomeInterface {
     // Do nothing
   }
-  
+
   private static class SomeInterfaceInstanceCreator implements InstanceCreator<SomeInterface> {
     @Override public SomeInterface createInstance(Type type) {
       return new SomeObject();
     }
   }
-  
+
   private static class ClassWithInterfaceField {
     @Expose
     private final SomeInterface interfaceField;
@@ -182,5 +176,5 @@ public class ExposeFieldsTest {
     public ClassWithInterfaceField(SomeInterface interfaceField) {
       this.interfaceField = interfaceField;
     }
-  }  
+  }
 }

--- a/gson/src/test/java/com/google/gson/functional/StreamingTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/StreamingTypeAdaptersTest.java
@@ -71,7 +71,7 @@ public final class StreamingTypeAdaptersTest {
     Truck truck = new Truck();
     truck.passengers = null;
     assertThat(truckAdapter.toJson(truck).replace('\"', '\''))
-        .isEqualTo("{'horsePower':0.0,'passengers':null}");
+        .isAnyOf("{'horsePower':0.0,'passengers':null}", "{'passengers':null,'horsePower':0.0}");
   }
 
   @Test
@@ -100,7 +100,8 @@ public final class StreamingTypeAdaptersTest {
     Truck truck = new Truck();
     truck.passengers = Arrays.asList(new Person("Jesse", 29), new Person("Jodie", 29));
     assertThat(truckAdapter.toJson(truck).replace('\"', '\''))
-        .isEqualTo("{'horsePower':0.0,'passengers':['Jesse','Jodie']}");
+        .isAnyOf("{'horsePower':0.0,'passengers':['Jesse','Jodie']}",
+                 "{'passengers':['Jesse','Jodie'],'horsePower':0.0}");
   }
 
   @Test
@@ -200,7 +201,8 @@ public final class StreamingTypeAdaptersTest {
     }
     gson = new GsonBuilder().registerTypeAdapter(Person.class, typeAdapter.nullSafe()).create();
     assertThat(gson.toJson(truck, Truck.class))
-        .isEqualTo("{\"horsePower\":1.0,\"passengers\":[null,\"jesse,30\"]}");
+        .isAnyOf("{\"horsePower\":1.0,\"passengers\":[null,\"jesse,30\"]}",
+                "{\"passengers\":[null,\"jesse,30\"],\"horsePower\":1.0}");
     truck = gson.fromJson(json, Truck.class);
     assertThat(truck.horsePower).isEqualTo(1.0D);
     assertThat(truck.passengers.get(0)).isNull();


### PR DESCRIPTION
### Purpose
Increase robustness of gson tests. 

### Description
There are 37 tests within gson has been reported as flaky when ran with the [NonDex](https://github.com/TestingResearchIllinois/NonDex)tool. The test failed because of the randomness of the function [Class.getDeclaredFields()](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--). As mentioned by [eamonnmcmanus](https://github.com/eamonnmcmanus) in [issue:2309](https://github.com/google/gson/issues/2309), the tests are fragile. I wish to improve the stability of these tests.

### Fix
Added all options that test results could be.

How this has been tested?

Java: openjdk version "11.0.20.1"
Maven: Apache Maven 3.6.3

Module build: Successful
Regular test: Successful
NonDex test passed after the fix.
